### PR TITLE
fix(auditing): Allow multiple checks use the same patch

### DIFF
--- a/test/auditing/test_check_discovery/tasks/correct_second_module/checks/check_more_stuff.py
+++ b/test/auditing/test_check_discovery/tasks/correct_second_module/checks/check_more_stuff.py
@@ -6,6 +6,10 @@ def check_another_dummy_function():
     return False
 
 
+def check_dummy_function_again():
+    return False
+
+
 def _non_check_function():
     pass
 

--- a/test/auditing/test_check_discovery/tasks/correct_second_module/metadata/check_more_stuff.yml
+++ b/test/auditing/test_check_discovery/tasks/correct_second_module/metadata/check_more_stuff.yml
@@ -12,3 +12,9 @@ category: Something written here
   title: This checks another dummy function
   description: |
     Always code as if the guy who ends up maintaining your code will be a violent psychopath who knows where you live.
+
+- id: check_dummy_function_again
+  title: This checks something dummy again
+  patch: patch_more_stuff.patch_dummy_function
+  description: |
+    Always code as if the guy who ends up maintaining your code will be a violent psychopath who knows where you live.

--- a/test/auditing/test_check_discovery/test_check_discovery.py
+++ b/test/auditing/test_check_discovery/test_check_discovery.py
@@ -21,24 +21,33 @@ def test_check_discovery__correct_modules(settings):
     uut.discover_checks()
     from zoo.auditing.check_discovery import KINDS, CHECKS, PATCHES
 
-    assert len(CHECKS) == 10
+    assert len(CHECKS) == 11
 
     assert {function.__name__ for function in CHECKS} == {
         "check_another_dummy_function",
         "check_dummy_function",
+        "check_dummy_function_again",
     }
 
     for function in CHECKS:
         assert function() == (function.__name__ == "check_dummy_function")
 
-    assert len(KINDS) == 2
+    assert len(KINDS) == 3
     assert set(KINDS.keys()) == {
         "something:check_dummy_function",
         "something:check_another_dummy_function",
+        "something:check_dummy_function_again",
     }
-    assert len(PATCHES) == 1
-    assert set(PATCHES.keys()) == {"something:check_dummy_function"}
+    assert len(PATCHES) == 2
+    assert set(PATCHES.keys()) == {
+        "something:check_dummy_function",
+        "something:check_dummy_function_again",
+    }
     assert KINDS["something:check_dummy_function"].apply_patch() is True
+    assert (
+        KINDS["something:check_dummy_function"].apply_patch
+        == KINDS["something:check_dummy_function_again"].apply_patch
+    )
 
 
 def test_check_discovery__members_not_functions(settings):


### PR DESCRIPTION
If two or more checks are linked to the same patch (via metadata), than only patch for one of the checks will work, the rest of them will return `TypeError: 'NoneType' object is not callable` when the `Kind.apply_patch` method is called. That's because `kind.apply_patch` will be `None` because the kind key will be missing from the `PATCH` variable.

It makes sense that you can have two checks which can be fixed by the same patch.