### PR TITLE
fix(repos): UnicodeDecodeError when searching for OpenApi spec

### DIFF
--- a/zoo/repos/views.py
+++ b/zoo/repos/views.py
@@ -48,6 +48,7 @@ def _parse_file(path, base=None):
         ResolutionError,
         ScannerError,
         ValidationError,
+        UnicodeDecodeError,
     ) as err:
         log.info(
             "repos.views.openapi.invalid", path=str(path.relative_to(base)), error=err


### PR DESCRIPTION
Prance fails when scanned file is a JSON and contains special characters. This is probably not the best way to handle it but defini. The error being raised in this case is:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 1703: character maps to <undefined>
```