### PR TITLE
fix(webpack): add NODE_OPTIONS to Dockerfile

### DIFF
--- a/webpack/Dockerfile
+++ b/webpack/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:12-alpine
 
+ENV NODE_OPTIONS="--max-old-space-size=2048"
+
 WORKDIR /app
 
 COPY package.json /app/


### PR DESCRIPTION
`make run` did not work previously because Webpack ran out of memory when building the `.less` files