### PR TITLE
feat(openapi): turn off strict validation

### DIFF
--- a/zoo/repos/utils.py
+++ b/zoo/repos/utils.py
@@ -26,8 +26,7 @@ def get_scm_module(provider):
     e.g.: repository.provider = 'gitlab' => return zoo.repos.gitlab
     """
     current_module = ".".join(__name__.split(".")[:-1])
-    scm_module = importlib.import_module(f".{provider}", current_module)
-    return scm_module
+    return importlib.import_module(f".{provider}", current_module)
 
 
 def download_repository(repository, fake_dir, sha=None):
@@ -56,7 +55,7 @@ def download_repository(repository, fake_dir, sha=None):
 
 def _parse_file(path, base=None):
     try:
-        parser = ResolvingParser(str(path))
+        parser = ResolvingParser(str(path), strict=False)
         return parser.specification
     except (
         AssertionError,


### PR DESCRIPTION
Setting the `strict` parameter to False during Open Api validation makes the definitions with `integers` as keys to pass.