### PR TITLE
Upgrading CI

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   bento:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Bento
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,7 +4,7 @@ on: push
 jobs:
   container:
     name: Container image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
 
   black:
     name: Code style
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: kiwicom/black:20.8b1
       options: -u root
@@ -44,7 +44,7 @@ jobs:
 
   commitsar:
     name: Commit message style
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -56,8 +56,8 @@ jobs:
 
   pre-commit:
     name: Static checks
-    runs-on: ubuntu-latest
-    container: kiwicom/pre-commit:2.6.0-full
+    runs-on: ubuntu-20.04
+    container: kiwicom/pre-commit:2.9.3
 
     steps:
       - uses: actions/checkout@v2
@@ -78,9 +78,9 @@ jobs:
 
   pylint:
     name: Pylint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
-      image: kiwicom/tox:3.19
+      image: kiwicom/tox:3.21.2
       options: -u root
 
     steps:
@@ -98,9 +98,9 @@ jobs:
 
   pytest:
     name: Pytest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
-      image: kiwicom/tox:3.19
+      image: kiwicom/tox:3.21.2
       options: -u root
 
     env:
@@ -153,7 +153,7 @@ jobs:
 
   migrations:
     name: Migrations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: container
 
     services:
@@ -183,7 +183,7 @@ jobs:
 
   sonarcloud:
     name: SonarCloud
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: pytest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   container:
     name: Container image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
 
   release-notes:
     name: Release Notes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.4.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -20,34 +20,27 @@ repos:
       - id: requirements-txt-fixer
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.12.0
+    rev: v0.15.0
     hooks:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.18.0
+    rev: v1.26.0
     hooks:
       - id: yamllint
-        exclude: test/*
+        exclude: test/
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.19.0
+    rev: v0.26.0
     hooks:
       - id: markdownlint
         language_version: system
 
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
-
   - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+    rev: 5.7.0
     hooks:
       - id: isort
-        # extra dependencies for config in pyproject.toml
-        additional_dependencies: ["isort[pyproject]"]
-        exclude: test\/.*\/snapshots\/*
+        exclude: test.*snapshots/
 
   - repo: https://github.com/psf/black
     rev: 20.8b1
@@ -57,11 +50,11 @@ repos:
         args: ["."]
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 4.0.1
+    rev: 5.1.1
     hooks:
       - id: pydocstyle
 
   - repo: https://github.com/codingjoe/relint
-    rev: 1.1.1
+    rev: 1.2.1
     hooks:
       - id: relint

--- a/shell.nix
+++ b/shell.nix
@@ -4,7 +4,7 @@ let pkgs = import <nixpkgs> {};
 in base.overrideAttrs (self: rec {
   buildInputs = self.buildInputs ++ [
     pkgs.yarn
-    pkgs.postgresql
+    pkgs.postgresql_12
   ];
 
   exportVarsHook=''


### PR DESCRIPTION
- Using pinned `ubuntu-20.04` to avoid warning and future suprises. See https://github.com/actions/virtual-environments/issues/1816
- Updated pre-commit hooks