### PR TITLE
feat: Set graphql endpoint to be local on client

### DIFF
--- a/frontend/packages/zoo-api/src/client.ts
+++ b/frontend/packages/zoo-api/src/client.ts
@@ -11,22 +11,9 @@ const cache = cacheExchange({
   },
 });
 
-function getToken(): string {
-  const value = localStorage.getItem("the-zoo.api.token");
-  if (!value) return "";
-  const token = JSON.parse(value)["token"];
-  return token ? token : "";
-}
-
 export const theZooClient = new Client({
-  url: 'http://127.0.0.1:8000/graphql',
+  url: '/graphql',
   exchanges: [cache, dedupExchange, fetchExchange],
-  fetchOptions: () => {
-    const token: string = getToken();
-    return {
-      headers: { Authorization: token ? `Bearer ${token}` : '' },
-    };
-  }
 });
 
 /**

--- a/zoo/base/settings.py
+++ b/zoo/base/settings.py
@@ -21,6 +21,7 @@ version = _get_app_version()
 root = Path(__file__).parents[1]
 env = environ.Env(
     ZOO_DEBUG=(bool, False),
+    ZOO_USE_HANGAR=(bool, False),
     ZOO_CELERY_BROKER_URL=(str, "redis://redis/0"),
     ZOO_REDIS_CACHE_URL=(str, "redis://redis/1"),
     ZOO_REDBEAT_REDIS_URL=(str, "redis://redis/2"),
@@ -152,6 +153,10 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+USE_HANGAR = env("ZOO_USE_HANGAR")
+if USE_HANGAR:
+    MIDDLEWARE.append("zoo.api.middleware.ApiTokenAuthenticationMiddleware")
 
 ROOT_URLCONF = "zoo.base.urls"
 

--- a/zoo/base/settings.py
+++ b/zoo/base/settings.py
@@ -155,7 +155,7 @@ MIDDLEWARE = [
 ]
 
 USE_HANGAR = env("ZOO_USE_HANGAR")
-if USE_HANGAR:
+if not USE_HANGAR:
     MIDDLEWARE.append("zoo.api.middleware.ApiTokenAuthenticationMiddleware")
 
 ROOT_URLCONF = "zoo.base.urls"

--- a/zoo/base/settings.py
+++ b/zoo/base/settings.py
@@ -151,7 +151,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "zoo.api.middleware.ApiTokenAuthenticationMiddleware",
 ]
 
 ROOT_URLCONF = "zoo.base.urls"


### PR DESCRIPTION
To access the zoo backend graphql endpoint through IAP authentication, and to avoid CORS issue the client will assume that the graphql is on the same domain (/graphql). During deployment we will make sure that /graphql is proxied to the correct zoo backend.