### PR TITLE
feat: add useApiTokenAuth config

### DIFF
--- a/frontend/app-config.yaml
+++ b/frontend/app-config.yaml
@@ -1,6 +1,7 @@
 app:
   title: Hangar App
   baseUrl: http://localhost:3000
+  useApiTokenAuth: false
 
 organization:
   name: Kiwi.com

--- a/frontend/packages/zoo-api/src/client.ts
+++ b/frontend/packages/zoo-api/src/client.ts
@@ -25,8 +25,8 @@ export const theZooClient = new Client({
   url: '/graphql',
   exchanges: [cache, dedupExchange, fetchExchange],
   fetchOptions: () => {
-      let config = useApi(configApiRef);
-      let useApiTokenAuth = config.getBoolean("app.useApiTokenAuth");
+      const config = useApi(configApiRef);
+      const useApiTokenAuth = config.getBoolean("app.useApiTokenAuth");
 
       if (useApiTokenAuth) {
           const token: string = getToken();

--- a/frontend/packages/zoo-api/src/client.ts
+++ b/frontend/packages/zoo-api/src/client.ts
@@ -34,7 +34,7 @@ export const theZooClient = new Client({
           };
       }
 
-      return {}
+      return {};
   }
 });
 

--- a/frontend/packages/zoo-api/src/client.ts
+++ b/frontend/packages/zoo-api/src/client.ts
@@ -33,6 +33,8 @@ export const theZooClient = new Client({
               headers: { Authorization: token ? `Bearer ${token}` : '' },
           };
       }
+
+      return {}
   }
 });
 

--- a/frontend/packages/zoo-api/src/client.ts
+++ b/frontend/packages/zoo-api/src/client.ts
@@ -15,7 +15,7 @@ const cache = cacheExchange({
 export const API_AUTH_KEY = "the-zoo.api.token";
 
 function getToken(): string {
-    const value = localeStorage.getItem(API_AUTH_KEY);
+    const value = localStorage.getItem(API_AUTH_KEY);
     if (!value) return "";
     const token = JSON.parse(value)["token"];
     return token ? token : "";

--- a/frontend/packages/zoo-api/src/client.ts
+++ b/frontend/packages/zoo-api/src/client.ts
@@ -12,9 +12,10 @@ const cache = cacheExchange({
   },
 });
 
+export const API_AUTH_KEY = "the-zoo.api.token";
 
 function getToken(): string {
-    const value = localeStorage.getItem("the-zoo.api.token");
+    const value = localeStorage.getItem(API_AUTH_KEY);
     if (!value) return "";
     const token = JSON.parse(value)["token"];
     return token ? token : "";

--- a/frontend/plugins/services/src/state/AppState.tsx
+++ b/frontend/plugins/services/src/state/AppState.tsx
@@ -1,12 +1,11 @@
 import React, { useReducer, Dispatch, Reducer } from 'react';
-import type { Action, SettingsState, State } from './types';
+import type { Action, SettingsState, State } from './types';\
 
 export type { SettingsState };
 
 export const AppContext = React.createContext<[State, Dispatch<Action>]>(
   [] as any,
 );
-export const STORAGE_KEY = "the-zoo.api.token";
 
 const initialState: State = {
   token: '',

--- a/frontend/plugins/services/src/state/AppState.tsx
+++ b/frontend/plugins/services/src/state/AppState.tsx
@@ -1,5 +1,5 @@
 import React, { useReducer, Dispatch, Reducer } from 'react';
-import type { Action, SettingsState, State } from './types';\
+import type { Action, SettingsState, State } from './types';
 
 export type { SettingsState };
 

--- a/frontend/plugins/services/src/state/useSettings.ts
+++ b/frontend/plugins/services/src/state/useSettings.ts
@@ -1,6 +1,6 @@
 import { errorApiRef, useApi } from '@backstage/core';
 import { useContext, useEffect } from 'react';
-import { AppContext, STORAGE_KEY } from './AppState';
+import { API_AUTH_KEY } from 'zoo-api';
 import { Settings } from './types';
 
 export function useSettings() {
@@ -11,8 +11,8 @@ export function useSettings() {
   useEffect(() => {
     const rehydrate = () => {
       try {
-        const stateFromStorage = JSON.parse(
-          localStorage.getItem(STORAGE_KEY)!,
+          const stateFromStorage = JSON.parse(
+              localStorage.getItem(API_AUTH_KEY)!,
         );
         if (
           stateFromStorage &&
@@ -33,7 +33,7 @@ export function useSettings() {
   }, [dispatch, errorApi, settings]);
 
   const persist = (state: Settings) => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    localStorage.setItem(API_AUTH_KEY, JSON.stringify(state));
   };
 
   return [

--- a/frontend/plugins/services/src/state/useSettings.ts
+++ b/frontend/plugins/services/src/state/useSettings.ts
@@ -2,6 +2,7 @@ import { errorApiRef, useApi } from '@backstage/core';
 import { useContext, useEffect } from 'react';
 import { API_AUTH_KEY } from 'zoo-api';
 import { Settings } from './types';
+import { AppContext } from './AppState'
 
 export function useSettings() {
   const [settings, dispatch] = useContext(AppContext);


### PR DESCRIPTION
This enables us to switch on/off authentication for the
graphql backend as on production we use Googles IAP